### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,8 @@ npm run quality       # Full quality check (lint + types + tests)
 ## License
 
 MIT -- [Purple Squirrel Media](https://github.com/ExpertVagabond)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/expertvagabond-solana-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/expertvagabond-solana-mcp-server).