### PR TITLE
fix(ci): vendor @psm/mcp-core-ts subset, drop unresolvable file: dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@modelcontextprotocol/sdk": "^1.20.0",
-        "@psm/mcp-core-ts": "file:../psm-mcp-core-ts",
         "@solana/spl-token": "^0.4.8",
         "@solana/web3.js": "^1.95.2",
         "bs58": "^5.0.0",
@@ -34,21 +33,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "../psm-mcp-core-ts": {
-      "name": "@psm/mcp-core-ts",
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.8.0"
-      },
-      "devDependencies": {
-        "@types/node": "^22.0.0",
-        "typescript": "^5.7.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2080,10 +2064,6 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
-    },
-    "node_modules/@psm/mcp-core-ts": {
-      "resolved": "../psm-mcp-core-ts",
-      "link": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.0",
-    "@psm/mcp-core-ts": "file:../psm-mcp-core-ts",
     "@solana/web3.js": "^1.95.2",
     "@solana/spl-token": "^0.4.8",
     "@coral-xyz/anchor": "^0.32.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
   validateNoInjection as psmValidateNoInjection,
   sanitizeError as psmSanitizeError,
   OutputFilter,
-} from "@psm/mcp-core-ts";
+} from "./psm-mcp-core.js";
 
 // ============================================================================
 // SECTION 0: PSM MCP Core — output filter instance (secrets + PII redaction)

--- a/src/psm-mcp-core.ts
+++ b/src/psm-mcp-core.ts
@@ -1,0 +1,269 @@
+/**
+ * Vendored subset of @psm/mcp-core-ts.
+ *
+ * PROVENANCE
+ *   Upstream:  github.com/ExpertVagabond/psm-mcp-core-ts (private)
+ *   Commit:    bb183cace8038df7fa9d77d55d77a5e2ac54702e (2026-03-31)
+ *   Files:     src/error.ts, src/input.ts, src/filter.ts
+ *   License:   MIT (same author) — see LICENSE
+ *
+ * WHY VENDORED
+ *   @psm/mcp-core-ts is not published to npm and its GitHub repository is
+ *   private, with dist/ excluded by .gitignore. The previous dependency spec
+ *   "@psm/mcp-core-ts": "file:../psm-mcp-core-ts" only resolved on a machine
+ *   that happened to have the sibling checkout, so it broke both CI (TS2307 at
+ *   install/build time) and any `npm install solana-mcp-server` by a consumer.
+ *   Copying the exact upstream implementations keeps the real behaviour and
+ *   real type-checking with no unresolvable dependency.
+ *
+ * KEEPING IN SYNC
+ *   The code below is byte-for-byte the upstream implementation, which itself
+ *   mirrors psm-mcp-core (Rust) 1:1. If the upstream regexes, error codes, or
+ *   redaction categories change, re-copy them here and bump the commit above.
+ *
+ * SCOPE
+ *   Only the surface used by src/index.ts is vendored:
+ *     - PsmMcpError    (error.ts) — thrown by validateNoInjection
+ *     - sanitizeError  (error.ts)
+ *     - validateNoInjection (input.ts)
+ *     - OutputFilter   (filter.ts)
+ */
+
+// ============================================================================
+// error.ts — Unified error type. Mirrors psm-mcp-core/src/error.rs 1:1.
+// ============================================================================
+
+export type PsmMcpErrorKind =
+  | "InputValidation"
+  | "ShellExec"
+  | "PolicyViolation"
+  | "Timeout"
+  | "Sandbox"
+  | "Config"
+  | "RateLimited"
+  | "NotFound"
+  | "PermissionDenied"
+  | "Internal";
+
+const ERROR_CODES: Record<PsmMcpErrorKind, number> = {
+  InputValidation: -32602,
+  ShellExec: -32603,
+  PolicyViolation: -32604,
+  Timeout: -32605,
+  Sandbox: -32606,
+  Config: -32607,
+  RateLimited: -32608,
+  NotFound: -32609,
+  PermissionDenied: -32610,
+  Internal: -32603,
+};
+
+export class PsmMcpError extends Error {
+  readonly kind: PsmMcpErrorKind;
+  readonly code: number;
+
+  constructor(kind: PsmMcpErrorKind, message: string) {
+    super(message);
+    this.name = "PsmMcpError";
+    this.kind = kind;
+    this.code = ERROR_CODES[kind];
+  }
+
+  static inputValidation(msg: string): PsmMcpError {
+    return new PsmMcpError("InputValidation", `input validation failed: ${msg}`);
+  }
+
+  static shellExec(msg: string): PsmMcpError {
+    return new PsmMcpError("ShellExec", `shell execution failed: ${msg}`);
+  }
+
+  static policyViolation(msg: string): PsmMcpError {
+    return new PsmMcpError("PolicyViolation", `policy violation: ${msg}`);
+  }
+
+  static timeout(ms: number): PsmMcpError {
+    return new PsmMcpError("Timeout", `timeout after ${ms}ms`);
+  }
+
+  static sandbox(msg: string): PsmMcpError {
+    return new PsmMcpError("Sandbox", `sandbox error: ${msg}`);
+  }
+
+  static config(msg: string): PsmMcpError {
+    return new PsmMcpError("Config", `configuration error: ${msg}`);
+  }
+
+  static rateLimited(retryAfterSecs: number): PsmMcpError {
+    return new PsmMcpError("RateLimited", `rate limited: retry after ${retryAfterSecs}s`);
+  }
+
+  static notFound(msg: string): PsmMcpError {
+    return new PsmMcpError("NotFound", `not found: ${msg}`);
+  }
+
+  static permissionDenied(msg: string): PsmMcpError {
+    return new PsmMcpError("PermissionDenied", `permission denied: ${msg}`);
+  }
+
+  static internal(msg: string): PsmMcpError {
+    return new PsmMcpError("Internal", msg);
+  }
+}
+
+// Mirrors: sanitize_error() in error.rs
+const PATH_RE = /(?:\/[a-zA-Z0-9._\-]+){3,}/g;
+
+/**
+ * Strip file paths, truncate to maxLen chars, redact tokens longer than 40 chars.
+ */
+export function sanitizeError(msg: string, maxLen = 300): string {
+  const stripped = msg.replace(PATH_RE, "[PATH]");
+  const words = stripped.split(/\s+/);
+  let out = "";
+  for (const word of words) {
+    const part = word.length > 40 ? "[REDACTED]" : word;
+    if (out.length + part.length + 1 >= maxLen) {
+      return out.slice(0, maxLen) + "...";
+    }
+    out += (out ? " " : "") + part;
+  }
+  return out;
+}
+
+// ============================================================================
+// input.ts — Input validation. Mirrors psm-mcp-core/src/input.rs 1:1.
+// ============================================================================
+
+// Injection patterns — reject inputs containing these.
+// Identical to Rust INJECTION_RE.
+const INJECTION_PATTERNS: Array<[string, RegExp]> = [
+  ["shell_meta", /[;|&`]/],
+  ["path_traversal", /\.\.[\\/]/],
+  ["null_byte", /\x00/],
+  ["newline_inject", /[\r\n]/],
+];
+
+/**
+ * Validate a string contains no shell injection characters.
+ */
+export function validateNoInjection(value: string, label: string): string {
+  for (const [category, re] of INJECTION_PATTERNS) {
+    if (re.test(value)) {
+      throw PsmMcpError.inputValidation(
+        `${label} contains forbidden characters (${category})`
+      );
+    }
+  }
+  return value;
+}
+
+// ============================================================================
+// filter.ts — Output filtering. Mirrors psm-mcp-core/src/filter.rs 1:1.
+// Same 9 secret patterns, same 4 PII patterns.
+// ============================================================================
+
+/** Record of a single redaction applied to output. */
+export interface Redaction {
+  category: string;
+  originalLength: number;
+}
+
+/** Result of filtering output text. */
+export interface FilterResult {
+  modified: boolean;
+  text: string;
+  redactions: Redaction[];
+}
+
+interface PatternDef {
+  name: string;
+  regex: RegExp;
+}
+
+// 9 secret patterns — identical to Rust SECRET_PATTERNS.
+const SECRET_PATTERNS: PatternDef[] = [
+  { name: "aws_key", regex: /AKIA[0-9A-Z]{16}/g },
+  {
+    name: "aws_secret",
+    regex: /aws[_\-]?secret[_\-]?access[_\-]?key\s*[=:]\s*\S{20,}/gi,
+  },
+  { name: "github_token", regex: /gh[ps]_[A-Za-z0-9_]{36,}/g },
+  {
+    name: "generic_api_key",
+    regex: /(api[_\-]?key|api[_\-]?secret)\s*[=:]\s*\S{16,}/gi,
+  },
+  { name: "jwt", regex: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}/g },
+  {
+    name: "private_key",
+    regex: /-----BEGIN\s+(?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g,
+  },
+  { name: "slack_token", regex: /xox[bpras]-[A-Za-z0-9\-]{10,}/g },
+  { name: "anthropic_key", regex: /sk-ant-[A-Za-z0-9_-]{20,}/g },
+  { name: "openai_key", regex: /sk-[A-Za-z0-9]{20,}/g },
+];
+
+// 4 PII patterns — identical to Rust PII_PATTERNS.
+const PII_PATTERNS: PatternDef[] = [
+  { name: "ssn", regex: /\b\d{3}-\d{2}-\d{4}\b/g },
+  {
+    name: "credit_card",
+    regex:
+      /\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6011)[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/g,
+  },
+  {
+    name: "email",
+    regex: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  },
+  {
+    name: "phone",
+    regex: /\b(?:\+1[\s-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/g,
+  },
+];
+
+/** Output filter that redacts secrets and PII from text. */
+export class OutputFilter {
+  private readonly filterSecrets: boolean;
+  private readonly filterPii: boolean;
+
+  constructor(filterSecrets = true, filterPii = true) {
+    this.filterSecrets = filterSecrets;
+    this.filterPii = filterPii;
+  }
+
+  /** Filter text, redacting secrets and/or PII. */
+  filter(text: string): FilterResult {
+    let result = text;
+    const redactions: Redaction[] = [];
+
+    const apply = (patterns: PatternDef[]) => {
+      for (const pat of patterns) {
+        // Reset regex lastIndex for global patterns.
+        pat.regex.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = pat.regex.exec(result)) !== null) {
+          redactions.push({
+            category: pat.name,
+            originalLength: match[0].length,
+          });
+        }
+        pat.regex.lastIndex = 0;
+        result = result.replace(
+          pat.regex,
+          `[REDACTED_${pat.name.toUpperCase()}]`
+        );
+      }
+    };
+
+    if (this.filterSecrets) apply(SECRET_PATTERNS);
+    if (this.filterPii) apply(PII_PATTERNS);
+
+    return {
+      modified: redactions.length > 0,
+      text: result,
+      redactions,
+    };
+  }
+}
+
+/** Default filter instance (secrets + PII). */
+export const defaultFilter = new OutputFilter();


### PR DESCRIPTION
## Problem

Every run of the **CI** workflow fails at the `npm ci` step (the root `prepare` script runs `npm run build`):

```
src/index.ts(27,8): error TS2307: Cannot find module '@psm/mcp-core-ts' or its corresponding type declarations.
npm error code 2
npm error command failed
npm error command sh -c npm run build
```

(The `Solana CLI installation failed, but MCP will work with web3.js` line earlier in the log is benign — `install-solana` has a `|| echo` fallback.)

## Root cause

`package.json` declared:

```json
"@psm/mcp-core-ts": "file:../psm-mcp-core-ts"
```

That spec only resolves on a machine that happens to have the sibling checkout next to this repo. Investigated before changing anything:

| Question | Answer |
| --- | --- |
| Published to npm? | **No** — `npm view @psm/mcp-core-ts` → `E404 Not Found` |
| Declared in package.json? | Yes, as `file:../psm-mcp-core-ts` |
| Resolvable from a sibling repo? | Only locally. GitHub repo `ExpertVagabond/psm-mcp-core-ts` is **private**, and `dist/` is gitignored there — so neither a registry dep nor a `github:` git dep can install without publishing the package or wiring a CI token |

This is not only a CI problem: npm records the relative path verbatim, so `npm install solana-mcp-server` would fail the same way for any consumer of the published package.

## Fix

Vendor the exact upstream implementations of the only three symbols `src/index.ts` imports — `validateNoInjection`, `sanitizeError`, `OutputFilter` (plus the `PsmMcpError` that `validateNoInjection` throws) — into `src/psm-mcp-core.ts`, copied byte-for-byte from `psm-mcp-core-ts@bb183ca` with provenance and re-sync instructions in the file header. The import becomes a relative path and the unresolvable dependency is dropped from `package.json` and `package-lock.json`.

The import is **not** deleted and the types are **not** stubbed — `tsc` still type-checks against the real implementations, and behaviour (error codes, injection categories, 9 secret + 4 PII redaction patterns) is unchanged.

Alternatives rejected: publishing `@psm/mcp-core-ts` to npm (makes a private package public — a call for the repo owner, not a CI fix); a `git+https` dep with a CI PAT (leaves CI red until a secret is added, and still needs a `prepare` build in the private repo because `dist/` is gitignored).

## Verification

Run against a clean clone with **no sibling checkout present**, mimicking the CI job steps (`npm ci` → lint → type-check → test → build) with install scripts enabled.

### Before (`master`)

```
########## STEP: npm ci (scripts enabled, runs prepare->build) ##########
> solana-mcp-server@1.0.1 prepare
> npm run build
> tsc
src/index.ts(27,8): error TS2307: Cannot find module '@psm/mcp-core-ts' or its corresponding type declarations.
npm error code 2
npm error command failed
npm error command sh -c npm run build
EXIT(npm ci)=2
EXIT(lint)=0            # 0 errors, 4 pre-existing warnings
EXIT(type-check)=2      # same TS2307
EXIT(test)=0            # "0/0 tests passed" — dist/index.js was never built, so nothing ran
EXIT(build)=2           # same TS2307
```

### After (this branch)

```
EXIT(npm ci)=0
EXIT(lint)=0            # 0 errors, same 4 pre-existing warnings
EXIT(type-check)=0
EXIT(test)=0            # 5/5 tests passed (real tests now run — dist/index.js exists)
EXIT(build)=0
```

Runtime smoke test of the vendored module against the compiled `dist/psm-mcp-core.js`:

```
injection -> PsmMcpError -32602 | input validation failed: addr contains forbidden characters (shell_meta)
clean     -> Abc123
sanitize  -> failed at [PATH] token [REDACTED]
filter    -> true | key [REDACTED_AWS_KEY] and mail [REDACTED_EMAIL]
             [{"category":"aws_key","originalLength":20},{"category":"email","originalLength":15}]
```

### CI on this PR (run 31417607312)

```
JOB: ci (20) => SUCCESS
   Install dependencies => success
   Run lint           => success
   Run type check     => success
   Run tests          => success
   Run build          => success
```

For comparison, the same job on `master` (run 27500748174) died at `Install dependencies`, skipping lint / type-check / tests / build entirely.

## Remaining failures on this PR — pre-existing, different root causes, not fixed here

Fixing the install/build blocker lets the later steps run for the first time, which exposes two defects that were previously masked. Both also fail on `master`; neither is related to `@psm/mcp-core-ts`.

1. **`ci (18)` — `Run lint`**: `ESLint: 10.1.0 / TypeError: util.styleText is not a function`. `util.styleText` does not exist on Node 18; eslint@^10 requires `^20.19.0 || ^22.13.0 || >=24`. The matrix still includes Node 18 (EOL April 2025). Fix is a separate call: drop 18 from the matrix, or pin eslint to 9.x.
2. **`security` — `Run security audit`**: `npm audit --audit-level moderate` over 24 advisories in the transitive tree. Fails identically on `master`; needs dependency upgrades, not a CI change.

## Risk

Low — behaviour is byte-identical to the code that was already being imported; the only new risk is silent drift if upstream `psm-mcp-core-ts` changes, which the provenance header in `src/psm-mcp-core.ts` (repo, commit, files, re-sync note) is there to catch.
